### PR TITLE
Makefile: let "test" doesn't depend on "all"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all:
 	go build -o kata-shim
 
-test: all
+test:
 	go test -v -race
 
 clean:


### PR DESCRIPTION
I think go test doesn't depend on binary.