### PR TITLE
Add version details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 TARGET = kata-shim
+SOURCES := $(shell find . 2>&1 | grep -E '.*\.go$$')
 
-$(TARGET):
+$(TARGET): $(SOURCES)
 	go build -o $@
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-all:
-	go build -o kata-shim
+TARGET = kata-shim
+
+$(TARGET):
+	go build -o $@
 
 test:
 	go test -v -race
 
 clean:
-	rm -f kata-shim
+	rm -f $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 TARGET = kata-shim
 SOURCES := $(shell find . 2>&1 | grep -E '.*\.go$$')
 
-$(TARGET): $(SOURCES)
-	go build -o $@
+VERSION_FILE := ./VERSION
+VERSION := $(shell grep -v ^\# $(VERSION_FILE))
+COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
+COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
+VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
+
+$(TARGET): $(SOURCES) $(VERSION_FILE)
+	go build -o $@ -ldflags "-X main.version=$(VERSION_COMMIT)"
 
 test:
 	go test -v -race

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,2 @@
+# This is the shim version.
+0.0.1

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"sync"
@@ -20,6 +21,9 @@ const (
 	shimName    = "kata-shim"
 	exitFailure = 1
 )
+
+// version is the shim version. This variable is populated at build time.
+var version = "unknown"
 
 var shimLog = logrus.WithFields(logrus.Fields{
 	"name": shimName,
@@ -36,6 +40,8 @@ func initLogger(logLevel string) error {
 
 	logrus.SetLevel(level)
 
+	shimLog.WithField("version", version).Info()
+
 	return nil
 }
 
@@ -46,8 +52,10 @@ func main() {
 		container     string
 		pid           uint
 		proxyExitCode bool
+		showVersion   bool
 	)
 
+	flag.BoolVar(&showVersion, "version", false, "display program version and exit")
 	flag.StringVar(&logLevel, "log", "warn", "set shim log level: debug, info, warn, error, fatal or panic")
 	flag.StringVar(&agentAddr, "agent", "", "agent gRPC socket endpoint")
 
@@ -56,6 +64,11 @@ func main() {
 	flag.BoolVar(&proxyExitCode, "proxy-exit-code", true, "proxy exit code of the process")
 
 	flag.Parse()
+
+	if showVersion {
+		fmt.Printf("%v version %v\n", shimName, version)
+		os.Exit(0)
+	}
 
 	if agentAddr == "" || container == "" || pid == 0 {
 		shimLog.WithField("agentAddr", agentAddr).WithField("container", container).WithField("pid", pid).Error("container ID, process ID and agent socket endpoint must be set")


### PR DESCRIPTION
build: Add version details to binary
    
Generate a version string containing version number and commit that the
shim logs when initialising the logger or when the user specifies
"-version".
