### PR TITLE
CI: Require 2 approvals for pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -6,10 +6,11 @@ requirements:
 
 # Disallow approval of PRs still under development
 always_pending:
-  title_regex: 'WIP'
+  title_regex: '(WIP|RFC)'
   labels:
     - do-not-merge
     - wip
+    - rfc
   explanation: 'Work in progress - do not merge'
 
 group_defaults:

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -26,6 +26,6 @@ group_defaults:
 
 groups:
   approvers:
-    required: 1
+    required: 2
     teams:
       - shim


### PR DESCRIPTION
Change the pullapprove configuration to require two acks before a PR
can be approved (for parity with the agent).

Fixes #13.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>