### PR TITLE
replace pid with exec id

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -30,9 +30,10 @@
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
+  branch = "master"
   name = "github.com/kata-containers/agent"
   packages = ["protocols/client","protocols/grpc","protocols/mockserver"]
-  revision = "9b50dbac719a0def765e3f4ad11eaa44d77b17e5"
+  revision = "8f22514ae5790f3b6953cf93692e663fa29469e3"
 
 [[projects]]
   name = "github.com/kr/pty"
@@ -112,6 +113,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "078abd4515403436b3faab35da3ca699b26031ce518a86c83c46d75b3f5d2dde"
+  inputs-digest = "030ac0204af3a20262e1228f3433c0eb02a69c8233c4dc7dd4ff28b60749e552"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,7 +25,7 @@
   go-tests = true
 
 [[constraint]]
-  revision = "9b50dbac719a0def765e3f4ad11eaa44d77b17e5"
+  revision = "8f22514ae5790f3b6953cf93692e663fa29469e3"
   name = "github.com/kata-containers/agent"
 
 [[constraint]]

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 		logLevel      string
 		agentAddr     string
 		container     string
-		pid           uint
+		execId        string
 		proxyExitCode bool
 		showVersion   bool
 	)
@@ -60,7 +60,7 @@ func main() {
 	flag.StringVar(&agentAddr, "agent", "", "agent gRPC socket endpoint")
 
 	flag.StringVar(&container, "container", "", "container id for the shim")
-	flag.UintVar(&pid, "pid", 0, "process id for the shim")
+	flag.StringVar(&execId, "exec-id", "", "process id for the shim")
 	flag.BoolVar(&proxyExitCode, "proxy-exit-code", true, "proxy exit code of the process")
 
 	flag.Parse()
@@ -70,8 +70,8 @@ func main() {
 		os.Exit(0)
 	}
 
-	if agentAddr == "" || container == "" || pid == 0 {
-		shimLog.WithField("agentAddr", agentAddr).WithField("container", container).WithField("pid", pid).Error("container ID, process ID and agent socket endpoint must be set")
+	if agentAddr == "" || container == "" || execId == "" {
+		shimLog.WithField("agentAddr", agentAddr).WithField("container", container).WithField("exec-id", execId).Error("container ID, exec ID and agent socket endpoint must be set")
 		os.Exit(exitFailure)
 	}
 
@@ -81,7 +81,7 @@ func main() {
 		os.Exit(exitFailure)
 	}
 
-	shim, err := newShim(agentAddr, container, uint32(pid))
+	shim, err := newShim(agentAddr, container, execId)
 	if err != nil {
 		shimLog.WithError(err).Error("failed to create new shim")
 		os.Exit(exitFailure)
@@ -108,7 +108,7 @@ func main() {
 	// wait until exit
 	exitcode, err := shim.wait()
 	if err != nil {
-		shimLog.WithError(err).WithField("pid", pid).Error("failed waiting for process")
+		shimLog.WithError(err).WithField("exec-id", execId).Error("failed waiting for process")
 		os.Exit(exitFailure)
 	} else if proxyExitCode {
 		shimLog.WithField("exitcode", exitcode).Info("using shim to proxy exit code")

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -16,10 +16,11 @@ func TestPipe(t *testing.T) {
 	defer testTearDown(agent)
 
 	containerId := "testContainer"
-	pid, err := agent.addContainer(containerId)
+	execId := "testExec"
+	err := agent.addContainer(containerId, execId)
 	assert.Nil(t, err, "failed to add new container: %s", err)
 
-	inPipe, outPipe, errPipe := shimStdioPipe(agent.ctx, agent.client, containerId, pid)
+	inPipe, outPipe, errPipe := shimStdioPipe(agent.ctx, agent.client, containerId, execId)
 
 	buf := []byte("foobar")
 	size, err := inPipe.Write(buf[:])
@@ -35,7 +36,7 @@ func TestPipe(t *testing.T) {
 	assert.Equal(t, size, 0, "unmatched write stdin pipe len %d:%d", 0, size)
 
 	// wrong process
-	inPipe, outPipe, errPipe = shimStdioPipe(agent.ctx, agent.client, containerId, pid+100)
+	inPipe, outPipe, errPipe = shimStdioPipe(agent.ctx, agent.client, containerId, execId+"foobar")
 	_, err = inPipe.Write(buf[:])
 	assert.NotNil(t, err, "Unexpected success writing stdin pipe")
 

--- a/shim.go
+++ b/shim.go
@@ -32,20 +32,20 @@ var sigIgnored = map[syscall.Signal]bool{
 
 type shim struct {
 	containerId string
-	pid         uint32
+	execId      string
 
 	ctx   context.Context
 	agent *shimAgent
 }
 
-func newShim(addr, containerId string, pid uint32) (*shim, error) {
+func newShim(addr, containerId, execId string) (*shim, error) {
 	if agent, err := newShimAgent(addr); err != nil {
 		return nil, err
 	} else {
 		return &shim{containerId: containerId,
-			pid:   pid,
-			ctx:   context.Background(),
-			agent: agent}, nil
+			execId: execId,
+			ctx:    context.Background(),
+			agent:  agent}, nil
 	}
 }
 
@@ -53,12 +53,12 @@ func (s *shim) proxyStdio(wg *sync.WaitGroup) {
 	// don't wait the copying of the stdin, because `io.Copy(inPipe, os.Stdin)`
 	// can't terminate when no input. todo: find a better way.
 	wg.Add(2)
-	inPipe, outPipe, errPipe := shimStdioPipe(s.ctx, s.agent, s.containerId, s.pid)
+	inPipe, outPipe, errPipe := shimStdioPipe(s.ctx, s.agent, s.containerId, s.execId)
 	go func() {
 		_, err1 := io.Copy(inPipe, os.Stdin)
 		_, err2 := s.agent.CloseStdin(s.ctx, &pb.CloseStdinRequest{
 			ContainerId: s.containerId,
-			PID:         s.pid})
+			ExecId:      s.execId})
 		if err1 != nil {
 			shimLog.WithError(err1).Warn("copy stdin failed")
 		}
@@ -101,7 +101,7 @@ func (s *shim) forwardAllSignals() chan os.Signal {
 			// forward this signal to container
 			_, err := s.agent.SignalProcess(s.ctx, &pb.SignalProcessRequest{
 				ContainerId: s.containerId,
-				PID:         s.pid,
+				ExecId:      s.execId,
 				Signal:      uint32(sysSig)})
 			if err != nil {
 				shimLog.WithError(err).WithField("signal", sig.String()).Error("forward signal failed")
@@ -120,7 +120,7 @@ func (s *shim) resizeTty(fromTty *os.File) error {
 
 	_, err = s.agent.TtyWinResize(s.ctx, &pb.TtyWinResizeRequest{
 		ContainerId: s.containerId,
-		PID:         s.pid,
+		ExecId:      s.execId,
 		Row:         uint32(ws.Height),
 		Column:      uint32(ws.Width)})
 	if err != nil {
@@ -144,7 +144,7 @@ func (s *shim) monitorTtySize(tty *os.File) {
 func (s *shim) wait() (int32, error) {
 	resp, err := s.agent.WaitProcess(s.ctx, &pb.WaitProcessRequest{
 		ContainerId: s.containerId,
-		PID:         s.pid})
+		ExecId:      s.execId})
 	if err != nil {
 		return 0, err
 	}

--- a/shim_test.go
+++ b/shim_test.go
@@ -18,15 +18,16 @@ func TestNewShim(t *testing.T) {
 	agent := testSetup(t)
 	defer testTearDown(agent)
 
-	id := "foobar"
-	pid, err := agent.addContainer(id)
+	contId := "foobarContainer"
+	execId := "testExec"
+	err := agent.addContainer(contId, execId)
 	assert.Nil(t, err, "%s", err)
 
-	shim, err := newShim(mockSockAddr, id, pid)
+	shim, err := newShim(mockSockAddr, contId, execId)
 	assert.Nil(t, err, "%s", err)
 	defer shim.agent.Close()
 
-	_, err = newShim(badMockAddr, id, pid)
+	_, err = newShim(badMockAddr, contId, execId)
 	assert.NotNil(t, err, "New shim with wrong socket address should fail")
 }
 
@@ -34,11 +35,12 @@ func TestShimOps(t *testing.T) {
 	agent := testSetup(t)
 	defer testTearDown(agent)
 
-	id := "foobar"
-	pid, err := agent.addContainer(id)
+	contId := "foobarContainer"
+	execId := "testExec"
+	err := agent.addContainer(contId, execId)
 	assert.Nil(t, err, "%s", err)
 
-	shim, err := newShim(mockSockAddr, id, pid)
+	shim, err := newShim(mockSockAddr, contId, execId)
 	assert.Nil(t, err, "%s", err)
 	defer shim.agent.Close()
 

--- a/vendor/github.com/kata-containers/agent/.travis.yml
+++ b/vendor/github.com/kata-containers/agent/.travis.yml
@@ -13,6 +13,9 @@ go_import_path: github.com/kata-containers/agent
 go:
   - 1.8
 
+before_script:
+  - ".ci/setup.sh"
+
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq automake

--- a/vendor/github.com/kata-containers/agent/Gopkg.lock
+++ b/vendor/github.com/kata-containers/agent/Gopkg.lock
@@ -44,7 +44,7 @@
 
 [[projects]]
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/empty","ptypes/timestamp","ptypes/wrappers"]
+  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
@@ -65,7 +65,7 @@
 
 [[projects]]
   name = "github.com/opencontainers/runc"
-  packages = ["libcontainer","libcontainer/apparmor","libcontainer/cgroups","libcontainer/cgroups/fs","libcontainer/cgroups/rootless","libcontainer/cgroups/systemd","libcontainer/configs","libcontainer/configs/validate","libcontainer/criurpc","libcontainer/keys","libcontainer/seccomp","libcontainer/stacktrace","libcontainer/system","libcontainer/user","libcontainer/utils"]
+  packages = ["libcontainer","libcontainer/apparmor","libcontainer/cgroups","libcontainer/cgroups/fs","libcontainer/cgroups/rootless","libcontainer/cgroups/systemd","libcontainer/configs","libcontainer/configs/validate","libcontainer/criurpc","libcontainer/keys","libcontainer/seccomp","libcontainer/specconv","libcontainer/stacktrace","libcontainer/system","libcontainer/user","libcontainer/utils"]
   revision = "2e7cfe036e2c6dc51ccca6eb7fa3ee6b63976dcd"
 
 [[projects]]
@@ -154,6 +154,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "11bc69fc5db2b10dc1fa6906c4a2b6f60ab9a6234540615a1d58b9a64a4460ba"
+  inputs-digest = "4f58481ed90edce8331933de5df28b3386c6374da473796ff0c48e846c209c36"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/kata-containers/agent/grpc_test.go
+++ b/vendor/github.com/kata-containers/agent/grpc_test.go
@@ -1,0 +1,104 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+)
+
+var testSharedPidNs = "testSharedPidNs"
+
+func testUpdateContainerConfigNamespaces(t *testing.T, sharedPidNs string, config, expected configs.Config) {
+	a := &agentGRPC{
+		sandbox: &sandbox{
+			sharedPidNs: namespace{
+				path: sharedPidNs,
+			},
+		},
+	}
+
+	err := a.updateContainerConfigNamespaces(&config)
+	assert.Nil(t, err, "updateContainerConfigNamespaces() failed: %v", err)
+
+	assert.True(t, reflect.DeepEqual(config, expected),
+		"Config structures should be identical: got %+v, expecting %+v",
+		config, expected)
+}
+
+func TestUpdateContainerConfigNamespacesNonEmptyConfig(t *testing.T) {
+	config := configs.Config{
+		Namespaces: []configs.Namespace{
+			{
+				Type: configs.NEWPID,
+			},
+		},
+	}
+
+	expectedConfig := configs.Config{
+		Namespaces: []configs.Namespace{
+			{
+				Type: configs.NEWPID,
+				Path: testSharedPidNs,
+			},
+		},
+	}
+
+	testUpdateContainerConfigNamespaces(t, testSharedPidNs, config, expectedConfig)
+}
+
+func TestUpdateContainerConfigNamespacesEmptyConfig(t *testing.T) {
+	expectedConfig := configs.Config{
+		Namespaces: []configs.Namespace{
+			{
+				Type: configs.NEWPID,
+				Path: testSharedPidNs,
+			},
+		},
+	}
+
+	testUpdateContainerConfigNamespaces(t, testSharedPidNs, configs.Config{}, expectedConfig)
+}
+
+func testUpdateContainerConfigPrivileges(t *testing.T, spec *specs.Spec, config, expected configs.Config) {
+	a := &agentGRPC{}
+
+	err := a.updateContainerConfigPrivileges(spec, &config)
+	assert.Nil(t, err, "updateContainerConfigPrivileges() failed: %v", err)
+
+	assert.True(t, reflect.DeepEqual(config, expected),
+		"Config structures should be identical: got %+v, expecting %+v",
+		config, expected)
+}
+
+func TestUpdateContainerConfigPrivilegesNilSpec(t *testing.T) {
+	testUpdateContainerConfigPrivileges(t, nil, configs.Config{}, configs.Config{})
+}
+
+func TestUpdateContainerConfigPrivilegesNilSpecProcess(t *testing.T) {
+	testUpdateContainerConfigPrivileges(t, &specs.Spec{}, configs.Config{}, configs.Config{})
+}
+
+func TestUpdateContainerConfigPrivilegesNoNewPrivileges(t *testing.T) {
+	for _, priv := range []bool{false, true} {
+		spec := &specs.Spec{
+			Process: &specs.Process{
+				NoNewPrivileges: priv,
+			},
+		}
+		config := configs.Config{}
+		expectedConfig := configs.Config{
+			NoNewPrivileges: priv,
+		}
+
+		testUpdateContainerConfigPrivileges(t, spec, config, expectedConfig)
+	}
+}

--- a/vendor/github.com/kata-containers/agent/protocols/grpc/agent.proto
+++ b/vendor/github.com/kata-containers/agent/protocols/grpc/agent.proto
@@ -16,7 +16,7 @@ import "google/protobuf/empty.proto";
 service AgentService {
 	// execution
 	rpc CreateContainer(CreateContainerRequest) returns (google.protobuf.Empty);
-	rpc StartContainer(StartContainerRequest) returns (NewProcessResponse);
+	rpc StartContainer(StartContainerRequest) returns (google.protobuf.Empty);
 
 	// RemoveContainer will tear down an existing container by forcibly terminating
 	// all processes running inside that container and releasing all internal
@@ -25,7 +25,7 @@ service AgentService {
 	// If any process can not be killed or if it can not be killed after
 	// the RemoveContainerRequest timeout, RemoveContainer will return an error.
 	rpc RemoveContainer(RemoveContainerRequest) returns (google.protobuf.Empty);
-	rpc ExecProcess(ExecProcessRequest) returns (NewProcessResponse);
+	rpc ExecProcess(ExecProcessRequest) returns (google.protobuf.Empty);
 	rpc SignalProcess(SignalProcessRequest) returns (google.protobuf.Empty);
 	rpc WaitProcess(WaitProcessRequest) returns (WaitProcessResponse); // wait & reap like waitpid(2)
 
@@ -51,9 +51,10 @@ service AgentService {
 
 message CreateContainerRequest {
 	string container_id = 1;
-	StringUser string_user = 2;
-	repeated Storage storages = 3;
-	Spec OCI = 4;
+	string exec_id = 2;
+	StringUser string_user = 3;
+	repeated Storage storages = 4;
+	Spec OCI = 5;
 }
 
 message StartContainerRequest {
@@ -71,32 +72,26 @@ message RemoveContainerRequest {
 	uint32 timeout = 2;
 }
 
-// NewProcessResponse contains a Linux PID for a process
-// that the agent created and manages.
-// Any gRPC request from the host for a PID that is not managed
-// by the agent will result in an error. For example, calling
-// WaitProcess() with a WaitProcessRequest pid field set to a
-// PID that was not created by the agent will return an error
-// back to the caller.
-message NewProcessResponse {
-	uint32 PID = 1;
-}
-
 message ExecProcessRequest {
 	string container_id = 1;
+	string exec_id = 2;
 	StringUser string_user = 3;
 	Process process = 4;
 }
 
 message SignalProcessRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+
+	// Special case for SignalProcess(): exec_id can be empty(""),
+	// which means to send the signal to all the processes including their descendants.
+	// Other APIs with exec_id should treat empty exec_id as an invalid request.
+	string exec_id = 2;
 	uint32 signal = 3;
 }
 
 message WaitProcessRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 }
 
 message WaitProcessResponse {
@@ -105,7 +100,7 @@ message WaitProcessResponse {
 
 message WriteStreamRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 	bytes data = 3;
 }
 
@@ -115,7 +110,7 @@ message WriteStreamResponse {
 
 message ReadStreamRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 	uint32 len = 3;
 }
 
@@ -125,12 +120,12 @@ message ReadStreamResponse {
 
 message CloseStdinRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 }
 
 message TtyWinResizeRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 	uint32 row = 3;
 	uint32 column = 4;
 }

--- a/vendor/github.com/kata-containers/agent/protocols/grpc/health.pb.go
+++ b/vendor/github.com/kata-containers/agent/protocols/grpc/health.pb.go
@@ -108,7 +108,10 @@ func init() {
 }
 func (this *CheckRequest) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*CheckRequest)
@@ -121,7 +124,10 @@ func (this *CheckRequest) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -132,7 +138,10 @@ func (this *CheckRequest) Equal(that interface{}) bool {
 }
 func (this *HealthCheckResponse) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*HealthCheckResponse)
@@ -145,7 +154,10 @@ func (this *HealthCheckResponse) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -156,7 +168,10 @@ func (this *HealthCheckResponse) Equal(that interface{}) bool {
 }
 func (this *VersionCheckResponse) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*VersionCheckResponse)
@@ -169,7 +184,10 @@ func (this *VersionCheckResponse) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}

--- a/vendor/github.com/kata-containers/agent/protocols/grpc/oci.pb.go
+++ b/vendor/github.com/kata-containers/agent/protocols/grpc/oci.pb.go
@@ -1499,7 +1499,10 @@ func init() {
 }
 func (this *Spec) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Spec)
@@ -1512,7 +1515,10 @@ func (this *Spec) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1560,7 +1566,10 @@ func (this *Spec) Equal(that interface{}) bool {
 }
 func (this *Process) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Process)
@@ -1573,7 +1582,10 @@ func (this *Process) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1632,7 +1644,10 @@ func (this *Process) Equal(that interface{}) bool {
 }
 func (this *Box) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Box)
@@ -1645,7 +1660,10 @@ func (this *Box) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1659,7 +1677,10 @@ func (this *Box) Equal(that interface{}) bool {
 }
 func (this *User) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*User)
@@ -1672,7 +1693,10 @@ func (this *User) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1697,7 +1721,10 @@ func (this *User) Equal(that interface{}) bool {
 }
 func (this *LinuxCapabilities) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxCapabilities)
@@ -1710,7 +1737,10 @@ func (this *LinuxCapabilities) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1758,7 +1788,10 @@ func (this *LinuxCapabilities) Equal(that interface{}) bool {
 }
 func (this *POSIXRlimit) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*POSIXRlimit)
@@ -1771,7 +1804,10 @@ func (this *POSIXRlimit) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1788,7 +1824,10 @@ func (this *POSIXRlimit) Equal(that interface{}) bool {
 }
 func (this *Mount) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Mount)
@@ -1801,7 +1840,10 @@ func (this *Mount) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1826,7 +1868,10 @@ func (this *Mount) Equal(that interface{}) bool {
 }
 func (this *Root) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Root)
@@ -1839,7 +1884,10 @@ func (this *Root) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1853,7 +1901,10 @@ func (this *Root) Equal(that interface{}) bool {
 }
 func (this *Hooks) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Hooks)
@@ -1866,7 +1917,10 @@ func (this *Hooks) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1898,7 +1952,10 @@ func (this *Hooks) Equal(that interface{}) bool {
 }
 func (this *Hook) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Hook)
@@ -1911,7 +1968,10 @@ func (this *Hook) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1941,7 +2001,10 @@ func (this *Hook) Equal(that interface{}) bool {
 }
 func (this *Linux) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Linux)
@@ -1954,7 +2017,10 @@ func (this *Linux) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2036,7 +2102,10 @@ func (this *Linux) Equal(that interface{}) bool {
 }
 func (this *Windows) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Windows)
@@ -2049,7 +2118,10 @@ func (this *Windows) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2060,7 +2132,10 @@ func (this *Windows) Equal(that interface{}) bool {
 }
 func (this *Solaris) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Solaris)
@@ -2073,7 +2148,10 @@ func (this *Solaris) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2084,7 +2162,10 @@ func (this *Solaris) Equal(that interface{}) bool {
 }
 func (this *LinuxIDMapping) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxIDMapping)
@@ -2097,7 +2178,10 @@ func (this *LinuxIDMapping) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2114,7 +2198,10 @@ func (this *LinuxIDMapping) Equal(that interface{}) bool {
 }
 func (this *LinuxNamespace) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxNamespace)
@@ -2127,7 +2214,10 @@ func (this *LinuxNamespace) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2141,7 +2231,10 @@ func (this *LinuxNamespace) Equal(that interface{}) bool {
 }
 func (this *LinuxDevice) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxDevice)
@@ -2154,7 +2247,10 @@ func (this *LinuxDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2183,7 +2279,10 @@ func (this *LinuxDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxResources) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxResources)
@@ -2196,7 +2295,10 @@ func (this *LinuxResources) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2235,7 +2337,10 @@ func (this *LinuxResources) Equal(that interface{}) bool {
 }
 func (this *LinuxMemory) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxMemory)
@@ -2248,7 +2353,10 @@ func (this *LinuxMemory) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2277,7 +2385,10 @@ func (this *LinuxMemory) Equal(that interface{}) bool {
 }
 func (this *LinuxCPU) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxCPU)
@@ -2290,7 +2401,10 @@ func (this *LinuxCPU) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2319,7 +2433,10 @@ func (this *LinuxCPU) Equal(that interface{}) bool {
 }
 func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxWeightDevice)
@@ -2332,7 +2449,10 @@ func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2352,7 +2472,10 @@ func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxThrottleDevice)
@@ -2365,7 +2488,10 @@ func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2382,7 +2508,10 @@ func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxBlockIO) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxBlockIO)
@@ -2395,7 +2524,10 @@ func (this *LinuxBlockIO) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2449,7 +2581,10 @@ func (this *LinuxBlockIO) Equal(that interface{}) bool {
 }
 func (this *LinuxPids) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxPids)
@@ -2462,7 +2597,10 @@ func (this *LinuxPids) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2473,7 +2611,10 @@ func (this *LinuxPids) Equal(that interface{}) bool {
 }
 func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxDeviceCgroup)
@@ -2486,7 +2627,10 @@ func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2509,7 +2653,10 @@ func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 }
 func (this *LinuxNetwork) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxNetwork)
@@ -2522,7 +2669,10 @@ func (this *LinuxNetwork) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2541,7 +2691,10 @@ func (this *LinuxNetwork) Equal(that interface{}) bool {
 }
 func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxHugepageLimit)
@@ -2554,7 +2707,10 @@ func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2568,7 +2724,10 @@ func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 }
 func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxInterfacePriority)
@@ -2581,7 +2740,10 @@ func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2595,7 +2757,10 @@ func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 }
 func (this *LinuxSeccomp) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxSeccomp)
@@ -2608,7 +2773,10 @@ func (this *LinuxSeccomp) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2635,7 +2803,10 @@ func (this *LinuxSeccomp) Equal(that interface{}) bool {
 }
 func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxSeccompArg)
@@ -2648,7 +2819,10 @@ func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2668,7 +2842,10 @@ func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 }
 func (this *LinuxSyscall) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxSyscall)
@@ -2681,7 +2858,10 @@ func (this *LinuxSyscall) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2708,7 +2888,10 @@ func (this *LinuxSyscall) Equal(that interface{}) bool {
 }
 func (this *LinuxIntelRdt) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxIntelRdt)
@@ -2721,7 +2904,10 @@ func (this *LinuxIntelRdt) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}


### PR DESCRIPTION
As discused in https://github.com/kata-containers/agent/pull/72, we'll
replace guest pid with runtime generated exec id to uniquely identify
a process.  