### PR TITLE
terminal: Properly set raw terminal only when needed

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -113,6 +113,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cf93da06b667cea7c7a26b35ec253051a06f67b16b36d1bceff6c399076bc26b"
+  inputs-digest = "ee82d5aef326424a4a8e96aa896b9e4879e2db90bdb2f697e55d2f08860aa8d3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,10 +29,6 @@
   name = "github.com/kata-containers/agent"
 
 [[constraint]]
-  name = "github.com/moby/moby"
-  version = "1.13.1"
-
-[[constraint]]
   name = "github.com/sirupsen/logrus"
   version = "v1.0.4"
 

--- a/terminal_linux.go
+++ b/terminal_linux.go
@@ -1,0 +1,51 @@
+// +build linux
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+const (
+	termiosIFlagRawTermInvMask = (unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)
+	termiosOFlagRawTermInvMask = unix.OPOST
+	termiosLFlagRawTermInvMask = (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
+	termiosCFlagRawTermInvMask = unix.PARENB
+	termiosCFlagRawTermMask    = unix.CS8
+	termiosCcVMinRawTermVal    = 1
+	termiosCcVTimeRawTermVal   = 0
+)
+
+func setupTerminal(fd int) (*unix.Termios, error) {
+	termios, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		return nil, err
+	}
+
+	var savedTermios unix.Termios
+	savedTermios = *termios
+
+	// Set the terminal in raw mode
+	termios.Iflag &^= termiosIFlagRawTermInvMask
+	termios.Oflag &^= termiosOFlagRawTermInvMask
+	termios.Lflag &^= termiosLFlagRawTermInvMask
+	termios.Cflag &^= termiosCFlagRawTermInvMask
+	termios.Cflag |= termiosCFlagRawTermMask
+	termios.Cc[unix.VMIN] = termiosCcVMinRawTermVal
+	termios.Cc[unix.VTIME] = termiosCcVTimeRawTermVal
+
+	if err := unix.IoctlSetTermios(fd, unix.TCSETS, termios); err != nil {
+		return nil, err
+	}
+
+	return &savedTermios, nil
+}
+
+func restoreTerminal(fd int, termios *unix.Termios) error {
+	return unix.IoctlSetTermios(fd, unix.TCSETS, termios)
+}

--- a/terminal_linux_test.go
+++ b/terminal_linux_test.go
@@ -1,0 +1,63 @@
+// +build linux
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	RawModeErr      = "should be properly set in raw mode"
+	FlagRawModeErr  = "flag " + RawModeErr
+	ValueRawModeErr = "value " + RawModeErr
+)
+
+func newTestTerminal(t *testing.T) (*os.File, error) {
+	if os.Getuid() != 0 {
+		t.Skip("Skipping this test: Requires to be root")
+		return nil, nil
+	}
+
+	return os.OpenFile("/dev/tty", os.O_RDWR, os.ModeDevice)
+}
+
+func TestSetupTerminalOnNonTerminalFailure(t *testing.T) {
+	file, err := ioutil.TempFile("", "tmp")
+	defer file.Close()
+	assert.Nil(t, err, "Failed to create temporary file")
+
+	_, err = setupTerminal(int(file.Fd()))
+	assert.NotNil(t, err, "Should fail because the file is not a terminal")
+}
+
+func TestSetupTerminalSuccess(t *testing.T) {
+	file, err := newTestTerminal(t)
+	defer file.Close()
+	assert.Nil(t, err, "Failed to create terminal")
+
+	savedTermios, err := setupTerminal(int(file.Fd()))
+	assert.Nil(t, err, "Should not fail because the file is a terminal")
+
+	termios, err := unix.IoctlGetTermios(int(file.Fd()), unix.TCGETS)
+	assert.Nil(t, err, "Failed to get terminal information")
+	assert.True(t, (termios.Iflag&termiosIFlagRawTermInvMask) == 0, "Termios I %s", FlagRawModeErr)
+	assert.True(t, (termios.Oflag&termiosOFlagRawTermInvMask) == 0, "Termios O %s", FlagRawModeErr)
+	assert.True(t, (termios.Lflag&termiosLFlagRawTermInvMask) == 0, "Termios L %s", FlagRawModeErr)
+	assert.True(t, (termios.Cflag&termiosCFlagRawTermInvMask) == 0, "Termios C %s", FlagRawModeErr)
+	assert.True(t, (termios.Cflag&termiosCFlagRawTermMask) == termiosCFlagRawTermMask, "Termios C %s", FlagRawModeErr)
+	assert.True(t, termios.Cc[unix.VMIN] == termiosCcVMinRawTermVal, "Termios CC VMIN %s", ValueRawModeErr)
+	assert.True(t, termios.Cc[unix.VTIME] == termiosCcVTimeRawTermVal, "Termios CC VTIME %s", ValueRawModeErr)
+
+	err = restoreTerminal(int(file.Fd()), savedTermios)
+	assert.Nil(t, err, "Terminal should be properly restored")
+}


### PR DESCRIPTION
This commit relies on unix package from golang instead of moby/moby
to get the terminal setup in raw mode.
Also, it fixes an issue about the terminal being set in raw mode
every time, even when STDIN was not a terminal.

Fixes #22

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>