### PR TITLE
[DNM] shim: wait on SIGUSR1 in case of init process

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/moby/moby/pkg/term"
@@ -90,6 +91,15 @@ func main() {
 	if err != nil {
 		logger().WithError(err).WithField("loglevel", logLevel).Error("invalid log level")
 		os.Exit(exitFailure)
+	}
+
+	// Wait on SIGUSR1 if it is an init process shim, in which case
+	// container ID equals to exec ID.
+	if container == execId {
+		waitSigUsr1 := make(chan os.Signal, 1)
+		signal.Notify(waitSigUsr1, syscall.SIGUSR1)
+		<-waitSigUsr1
+		signal.Stop(waitSigUsr1)
 	}
 
 	shim, err := newShim(agentAddr, container, execId)


### PR DESCRIPTION
In order to support `kata runtime create --pid-file` option,
kata runtime need to start shim before starting container. Make
shim wait on SIGUSR1 so that runtime can notify shim to proceed
after it starts the container.

Fixes #27

Signed-off-by: Peng Tao <bergwolf@gmail.com>