### PR TITLE
CI: Run central go test script

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+run_go_test

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -23,3 +23,9 @@ run_static_checks()
 	clone_tests_repo
 	bash "$tests_repo_dir/.ci/static-checks.sh"
 }
+
+run_go_test()
+{
+	clone_tests_repo
+	bash "$tests_repo_dir/.ci/go-test.sh"
+}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(TARGET): $(SOURCES) $(VERSION_FILE)
 	go build -o $@ -ldflags "-X main.version=$(VERSION_COMMIT)"
 
 test:
-	go test -v -race -coverprofile=coverage.txt -covermode=atomic
+	bash .ci/go-test.sh
 
 clean:
 	rm -f $(TARGET)


### PR DESCRIPTION
Run `go test` via the tests repositories script. This will allow all
the unit test logic to be confined to a single location and ensure
cross-repository consistency.

Fixes #33.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>