### PR TITLE
logger: Fix syslog identifier

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func initLogger(logLevel string) error {
 
 	shimLog.SetLevel(level)
 
-	hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_INFO|syslog.LOG_USER, "")
+	hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_INFO|syslog.LOG_USER, shimName)
 	if err == nil {
 		shimLog.AddHook(hook)
 	}


### PR DESCRIPTION
Ensure log entries specify the name of the shim, not its path.

Fixes #35.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>