### PR TITLE
shim: Fix not ordered output because of stderr usage on terminal

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func main() {
 
 	// stdio
 	wg := &sync.WaitGroup{}
-	shim.proxyStdio(wg)
+	shim.proxyStdio(wg, terminal)
 	defer wg.Wait()
 
 	// winsize

--- a/shim_test.go
+++ b/shim_test.go
@@ -51,7 +51,7 @@ func TestShimOps(t *testing.T) {
 	shim.resizeTty(tty)
 
 	wg := &sync.WaitGroup{}
-	shim.proxyStdio(wg)
+	shim.proxyStdio(wg, true)
 
 	sigc := shim.forwardAllSignals()
 	defer signal.Stop(sigc)


### PR DESCRIPTION
This commit fixes a sporadic behavior about the output returned by the
shim when the terminal is set. In this specific case, the shim should
not call into ReadStderr() because there is only one output coming out
of the terminal. And when the shim does that, we have no control over
which output is printed first. That's why using only ReadStdout() in
case of terminal is a proper solution.

Fixes #42

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>