### PR TITLE
shim: support entering specified network namespace

### DIFF
--- a/nsenter/namespace.h
+++ b/nsenter/namespace.h
@@ -1,0 +1,19 @@
+/* Copyright 2018 HyperHQ Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NSENTER_NAMESPACE_H
+#define NSENTER_NAMESPACE_H
+
+#ifndef _GNU_SOURCE
+#	define _GNU_SOURCE
+#endif
+#include <sched.h>
+
+/* All of these are taken from include/uapi/linux/sched.h */
+#ifndef CLONE_NEWNET
+#	define CLONE_NEWNET 0x40000000 /* New network namespace */
+#endif
+
+#endif /* NSENTER_NAMESPACE_H */

--- a/nsenter/nsenter.c
+++ b/nsenter/nsenter.c
@@ -1,0 +1,36 @@
+/* Copyright 2018 HyperHQ Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+/* Get all of the CLONE_NEW* flags. */
+#include "namespace.h"
+
+int nsenter(int nsPid)
+{
+	int nsFd, ret;
+	char *path;
+
+	path = malloc(sizeof(char)*64);
+	if (path == NULL)
+		return -1;
+	sprintf(path, "/proc/%d/ns/net", nsPid);
+	nsFd = open(path, O_RDONLY);
+	if (nsFd < 0) {
+		free(path);
+		return -1;
+	}
+	ret = setns(nsFd, CLONE_NEWNET);
+
+	free(path);
+	close(nsFd);
+	return ret;
+}

--- a/nsenter/nsenter.go
+++ b/nsenter/nsenter.go
@@ -1,0 +1,18 @@
+// +build linux
+
+// Copyright 2018 HyperHQ Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package nsenter
+
+/*
+#cgo CFLAGS: -Wall
+extern int nsenter(int pid);
+*/
+import "C"
+
+func NsEnter(nsPid int) bool {
+	return C.nsenter(C.int(nsPid)) >= 0
+}

--- a/nsenter/nsenter_unsupported.go
+++ b/nsenter/nsenter_unsupported.go
@@ -1,0 +1,12 @@
+// Copyright 2018 HyperHQ Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// +build !linux !cgo
+
+package nsenter
+
+func NsEnter(nsPid int) bool {
+	return false
+}


### PR DESCRIPTION
In docker case, a container can join the network namespace of another
container. In runv, we solved it by letting `runv shim` own the network
namespace and if a new container needs to enter the netns, we make its
shim join the netns.

Fixes: #44