### PR TITLE
log: Discard logs going to stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log/syslog"
 	"os"
 	"os/signal"
@@ -44,6 +45,9 @@ func initLogger(logLevel string) error {
 	}
 
 	shimLog.SetLevel(level)
+
+	// Make sure all output going to stdout/stderr is actually discarded.
+	shimLog.Out = ioutil.Discard
 
 	hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_INFO|syslog.LOG_USER, shimName)
 	if err == nil {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,46 @@
+// Copyright 2018 Intel Corporation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitLogger(t *testing.T) {
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+
+	r, w, err := os.Pipe()
+	assert.Nil(t, err, "Could not create the pipe: %v", err)
+	os.Stdout = w
+	os.Stderr = w
+	defer func() {
+		r.Close()
+		w.Close()
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	testOutString := "Foo Bar"
+	initLogger("debug")
+	logger().Info(testOutString)
+
+	outC := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	w.Close()
+	out := <-outC
+	assert.Equal(t, out, "", "Expecting %q to be empty", out)
+}


### PR DESCRIPTION
By default, the logrus logger redirect the logs to stderr of the
shim. This happens even when the syslog hook is added, meaning logs
are both printed to stderr and the system journal.

We cannot let this happen since those logs should not be routed back
to the output of the shim, giving some weird output while you only
expect the output coming from the command executed on the container.

That's why this commit redirects those logs to a fake io.Writer called
devNull, defining a null operation, and returning instantly when the
writer is called. This leaves only the system journal being written.

Fixes #46

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>