### PR TITLE
shim: Fix race condition about I/O

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,11 +99,6 @@ func main() {
 		os.Exit(exitFailure)
 	}
 
-	// stdio
-	wg := &sync.WaitGroup{}
-	shim.proxyStdio(wg, terminal)
-	defer wg.Wait()
-
 	// winsize
 	if terminal {
 		termios, err := setupTerminal(int(os.Stdin.Fd()))
@@ -118,6 +113,15 @@ func main() {
 	// signals
 	sigc := shim.forwardAllSignals()
 	defer signal.Stop(sigc)
+
+	// This wait call cannot be deferred and has to wait for every
+	// input/output to return before the code tries to go further
+	// and wait for the process. Indeed, after the process has been
+	// waited for, we cannot expect to do any more calls related to
+	// this process since it is going to be removed from the agent.
+	wg := &sync.WaitGroup{}
+	shim.proxyStdio(wg, terminal)
+	wg.Wait()
 
 	// wait until exit
 	exitcode, err := shim.wait()


### PR DESCRIPTION
We need the I/O to be waited for before we try to wait for the
process. If we don't do this, the WaitProcess() call can return
before all the calls to ReadStdout(), ReadStderr and CloseStdin().
This leads to the shim failure (exits) when call into CloseStdin()
for instance. This happens because WaitProcess() delete everything
related to the process from the agent. We cannot expect to do further
calls after WaitProcess() returned.

Fixes #48

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>