### PR TITLE
main: coredump on internal error

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"log/syslog"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -58,6 +59,11 @@ func initLogger(logLevel string) error {
 	logger().WithField("version", version).Info()
 
 	return nil
+}
+
+func init() {
+	// Force coredump + full stacktrace on internal error
+	debug.SetTraceback("crash")
 }
 
 func main() {


### PR DESCRIPTION
Override the default golang panic handling by printing a full traceback
(not just for the current goroutine) and dumping core to allow
crash-handling programs to log the details.

Fixes #57.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>