### PR TITLE
main: stacktrace/coredump on error

### DIFF
--- a/fatal.go
+++ b/fatal.go
@@ -1,0 +1,70 @@
+// Copyright 2018 Intel Corporation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime/pprof"
+	"strings"
+	"syscall"
+)
+
+// List of fatal signals
+var sigFatal = map[syscall.Signal]bool{
+	syscall.SIGABRT:   true,
+	syscall.SIGBUS:    true,
+	syscall.SIGILL:    true,
+	syscall.SIGQUIT:   true,
+	syscall.SIGSEGV:   true,
+	syscall.SIGSTKFLT: true,
+	syscall.SIGSYS:    true,
+	syscall.SIGTRAP:   true,
+}
+
+func handlePanic() {
+	r := recover()
+
+	if r != nil {
+		msg := fmt.Sprintf("%s", r)
+		logger().WithField("panic", msg).Error("fatal error")
+
+		die()
+	}
+}
+
+func backtrace() {
+	profiles := pprof.Profiles()
+
+	buf := &bytes.Buffer{}
+
+	for _, p := range profiles {
+		// The magic number requests a full stacktrace. See
+		// https://golang.org/pkg/runtime/pprof/#Profile.WriteTo.
+		pprof.Lookup(p.Name()).WriteTo(buf, 2)
+	}
+
+	for _, line := range strings.Split(buf.String(), "\n") {
+		logger().Error(line)
+	}
+}
+
+func fatalSignal(sig syscall.Signal) bool {
+	return sigFatal[sig]
+}
+
+func die() {
+	backtrace()
+
+	if crashOnError {
+		signal.Reset(syscall.SIGABRT)
+		syscall.Kill(0, syscall.SIGABRT)
+	}
+
+	os.Exit(1)
+}

--- a/shim.go
+++ b/shim.go
@@ -25,9 +25,6 @@ var sigIgnored = map[syscall.Signal]bool{
 	syscall.SIGCHLD:  true,
 	syscall.SIGPIPE:  true,
 	syscall.SIGWINCH: true,
-	syscall.SIGBUS:   true,
-	syscall.SIGSEGV:  true,
-	syscall.SIGABRT:  true,
 }
 
 type shim struct {
@@ -103,6 +100,12 @@ func (s *shim) forwardAllSignals() chan os.Signal {
 				logger().WithError(err).WithField("signal", sig.String()).Error("")
 				continue
 			}
+
+			if fatalSignal(sysSig) {
+				logger().WithField("signal", sig).Error("received fatal signal")
+				die()
+			}
+
 			if sigIgnored[sysSig] {
 				//ignore these
 				continue


### PR DESCRIPTION
If the shim fails due to an internal error or if it receives a fatal
signal, write a stack trace to the log and exit.

If it was started with `--debug` also dump core.

Fixes #57.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>