### PR TITLE
test: Remove unused code

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -85,12 +85,6 @@ func testTearDown(t *testAgent) {
 	<-t.waitCh
 }
 
-var defaultSpec = &pb.Spec{
-	Process:  &pb.Process{},
-	Root:     &pb.Root{Path: "rootpath", Readonly: true},
-	Hostname: "testGuest",
-}
-
 func newTestSpec() *pb.Spec {
 	return &pb.Spec{
 		Version: "testGrpcVersion",


### PR DESCRIPTION
Remove unused `defaultSpec`.

Fixes #60.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>