### PR TITLE
logging: Only log actual I/O errors

### DIFF
--- a/shim.go
+++ b/shim.go
@@ -73,14 +73,20 @@ func (s *shim) proxyStdio(wg *sync.WaitGroup, terminal bool) {
 
 	go func() {
 		_, err := io.Copy(os.Stdout, outPipe)
-		logger().WithError(err).Info("copy stdout failed")
+		if err != nil {
+			logger().WithError(err).Info("copy stdout failed")
+		}
+
 		wg.Done()
 	}()
 
 	if !terminal {
 		go func() {
 			_, err := io.Copy(os.Stderr, errPipe)
-			logger().WithError(err).Info("copy stderr failed")
+			if err != nil {
+				logger().WithError(err).Info("copy stderr failed")
+			}
+
 			wg.Done()
 		}()
 	}


### PR DESCRIPTION
Fixed bug in `shim.proxyStdio()` which was unconditionally logging
errors in a couple of places, even when there wasn't one.

Fixes #68.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>