### PR TITLE
Improve resize messages

### DIFF
--- a/shim.go
+++ b/shim.go
@@ -126,7 +126,7 @@ func (s *shim) forwardAllSignals() chan os.Signal {
 func (s *shim) resizeTty(fromTty *os.File) error {
 	ws, err := term.GetWinsize(fromTty.Fd())
 	if err != nil {
-		logger().WithError(err).Info("Error getting size")
+		logger().WithError(err).Info("Error getting window size")
 		return nil
 	}
 
@@ -136,7 +136,7 @@ func (s *shim) resizeTty(fromTty *os.File) error {
 		Row:         uint32(ws.Height),
 		Column:      uint32(ws.Width)})
 	if err != nil {
-		logger().WithError(err).Error("set winsize failed")
+		logger().WithError(err).Error("set window size failed")
 	}
 
 	return err

--- a/shim.go
+++ b/shim.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 
 	"github.com/moby/moby/pkg/term"
+	"github.com/sirupsen/logrus"
 	context "golang.org/x/net/context"
 
 	pb "github.com/kata-containers/agent/protocols/grpc"
@@ -138,7 +139,10 @@ func (s *shim) resizeTty(fromTty *os.File) error {
 		Row:         uint32(ws.Height),
 		Column:      uint32(ws.Width)})
 	if err != nil {
-		logger().WithError(err).Error("set window size failed")
+		logger().WithError(err).WithFields(logrus.Fields{
+			"window-height": ws.Height,
+			"window-width":  ws.Width,
+		}).Error("set window size failed")
 	}
 
 	return err

--- a/shim.go
+++ b/shim.go
@@ -124,9 +124,11 @@ func (s *shim) forwardAllSignals() chan os.Signal {
 }
 
 func (s *shim) resizeTty(fromTty *os.File) error {
-	ws, err := term.GetWinsize(fromTty.Fd())
+	fd := fromTty.Fd()
+
+	ws, err := term.GetWinsize(fd)
 	if err != nil {
-		logger().WithError(err).Info("Error getting window size")
+		logger().WithError(err).WithField("fd", fd).Info("Error getting window size")
 		return nil
 	}
 


### PR DESCRIPTION
- Log the window width and height if the resize fails.
- Add an `fd` field showing the file descriptor when resizing the window fails.
- Be more consistent with the log messages when trying to resize the window.

Fixes #70.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>