### PR TITLE
logger: Add container + execID

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -30,7 +30,7 @@ func TestInitLogger(t *testing.T) {
 	}()
 
 	testOutString := "Foo Bar"
-	initLogger("debug")
+	initLogger("debug", "container-id", "exec-id")
 	logger().Info(testOutString)
 
 	outC := make(chan string)


### PR DESCRIPTION
Since there is a single shim process per container process, add the
container and execID to all log calls to make analysis easier.

Fixes #72.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>