### PR TITLE
tests: skip test if tty is not available

### DIFF
--- a/.ci/faketty.sh
+++ b/.ci/faketty.sh
@@ -8,4 +8,10 @@ set -e
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
-run_go_test
+# function to run unit test always with a tty
+function faketty()
+{
+	script -qfc $@;
+}
+
+faketty $@

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ $(TARGET): $(SOURCES) $(VERSION_FILE)
 	go build -o $@ -ldflags "-X main.version=$(VERSION_COMMIT)"
 
 test:
+	@echo "Go tests using faketty"
+	bash .ci/faketty.sh .ci/go-test.sh
+	#Run again without fake tty to avoid hide any potential issue.
+	@echo "Go tests without faketty"
 	bash .ci/go-test.sh
 
 clean:

--- a/terminal_linux_test.go
+++ b/terminal_linux_test.go
@@ -10,6 +10,7 @@ package main
 import (
 	"io/ioutil"
 	"os"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +43,16 @@ func TestSetupTerminalOnNonTerminalFailure(t *testing.T) {
 
 func TestSetupTerminalSuccess(t *testing.T) {
 	file, err := newTestTerminal(t)
+
+	if perr, ok := err.(*os.PathError); ok {
+		switch perr.Err.(syscall.Errno) {
+		case syscall.ENXIO:
+			t.Skip("Skipping this test: Failed to open tty, make sure test is running in a tty")
+		default:
+			t.Fatalf("could not open tty %s", err)
+		}
+	}
+
 	assert.Nil(t, err, "Failed to create terminal")
 	defer file.Close()
 


### PR DESCRIPTION
If the test is not running in a tty, skip it.

Tty is needed by the test.

Fixes: #75

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>