### PR TITLE
CI: Make faketty pass return code back to caller

### DIFF
--- a/.ci/faketty.sh
+++ b/.ci/faketty.sh
@@ -11,7 +11,7 @@ source "${cidir}/lib.sh"
 # function to run unit test always with a tty
 function faketty()
 {
-	script -qfc $@;
+	script -qfec $@;
 }
 
 faketty $@


### PR DESCRIPTION
Added `-e` `script(1)` argument to `.ci/faketty.sh` to ensure the caller
is notified when the script being run by `script(1)` fails.

Fixes #84.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>