### PR TITLE
CI: Update bash on Travis osx for hash support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_script:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq              ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y -qq automake ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bash; fi
 
 install:
   - cd ${TRAVIS_BUILD_DIR} && make


### PR DESCRIPTION
The version of `bash(1)` provided in the Travis osx environment does
not support `typeset -A`, so update it using homebrew.

Fixes #98.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>