### PR TITLE
signals: Allow SIGWINCH to be passed to container

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,10 +141,9 @@ func realMain() {
 		}
 		defer restoreTerminal(int(os.Stdin.Fd()), termios)
 	}
-	shim.monitorTtySize(os.Stdin)
 
 	// signals
-	sigc := shim.handleSignals()
+	sigc := shim.handleSignals(os.Stdin)
 	defer signal.Stop(sigc)
 
 	// This wait call cannot be deferred and has to wait for every

--- a/main.go
+++ b/main.go
@@ -144,7 +144,7 @@ func realMain() {
 	shim.monitorTtySize(os.Stdin)
 
 	// signals
-	sigc := shim.forwardAllSignals()
+	sigc := shim.handleSignals()
 	defer signal.Stop(sigc)
 
 	// This wait call cannot be deferred and has to wait for every

--- a/shim.go
+++ b/shim.go
@@ -115,6 +115,8 @@ func (s *shim) handleSignals(tty *os.File) chan os.Signal {
 				continue
 			}
 
+			logger().WithField("signal", sig).Debug("handling signal")
+
 			if sysSig == syscall.SIGWINCH {
 				s.resizeTty(tty)
 
@@ -124,7 +126,8 @@ func (s *shim) handleSignals(tty *os.File) chan os.Signal {
 				// the signal to the real workload.
 				continue
 			} else if debug && nonFatalSignal(sysSig) {
-				logger().WithField("signal", sig).Debug("handling signal")
+				// only backtrace in debug mode for security
+				// reasons.
 				backtrace()
 			}
 

--- a/shim.go
+++ b/shim.go
@@ -93,7 +93,8 @@ func (s *shim) proxyStdio(wg *sync.WaitGroup, terminal bool) {
 	}
 }
 
-func (s *shim) forwardAllSignals() chan os.Signal {
+// handleSignals performs all signal handling.
+func (s *shim) handleSignals() chan os.Signal {
 	sigc := make(chan os.Signal, sigChanSize)
 	// handle all signals for the process.
 	signal.Notify(sigc)

--- a/shim_test.go
+++ b/shim_test.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"os"
 	"os/signal"
 	"sync"
 	"testing"
@@ -53,10 +54,8 @@ func TestShimOps(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	shim.proxyStdio(wg, true)
 
-	sigc := shim.forwardAllSignals()
+	sigc := shim.handleSignals(os.Stdin)
 	defer signal.Stop(sigc)
-
-	shim.monitorTtySize(tty)
 
 	status, err := shim.wait()
 	assert.Nil(t, err, "%s", err)


### PR DESCRIPTION
Move tty handling to signal handler and stop ignoring `SIGWINCH` to allow this to be passed to the container workload.

Fixes #74.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>