### PR TITLE
shim: build as Position-Independent-Executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,11 @@ VERSION := $(shell grep -v ^\# $(VERSION_FILE))
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
 VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
+# go build common flags
+BUILDFLAGS := -buildmode=pie
 
 $(TARGET): $(SOURCES) $(VERSION_FILE)
-	go build -o $@ -ldflags "-X main.version=$(VERSION_COMMIT)"
+	go build $(BUILDFLAGS) -o $@ -ldflags "-X main.version=$(VERSION_COMMIT)"
 
 test:
 	@echo "Go tests using faketty"


### PR DESCRIPTION
Build the shim binary as Position-Independent-Executable (PIE) for improved
security and compliancy with distros packaging guidelines.

Fixes: #118