### PR TITLE
logger: log to std logger if shimLog is not yet inited

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,10 @@ var tracing = false
 var shimLog *logrus.Entry
 
 func logger() *logrus.Entry {
-	return shimLog
+	if shimLog != nil {
+		return shimLog
+	}
+	return logrus.NewEntry(logrus.StandardLogger())
 }
 
 func initLogger(logLevel, container, execID string, announceFields logrus.Fields, loggerOutput io.Writer) error {


### PR DESCRIPTION
Return a standard logger entry, if shimLog pointer is not yet initialized
to avoid SIGSEGV on init.

Fixes: #131