### PR TITLE
lint: Switch golang linter to golangci-lint

### DIFF
--- a/terminal_linux.go
+++ b/terminal_linux.go
@@ -27,8 +27,7 @@ func setupTerminal(fd int) (*unix.Termios, error) {
 		return nil, err
 	}
 
-	var savedTermios unix.Termios
-	savedTermios = *termios
+	savedTermios := *termios
 
 	// Set the terminal in raw mode
 	termios.Iflag &^= termiosIFlagRawTermInvMask


### PR DESCRIPTION
gometalinter is deprecated and will be archived April '19. The
suggestion is to switch to golangci-lint which is apparently 5x faster
than gometalinter.

Partially fixes: github.com/kata-containers/runtime#1377