### PR TITLE
ci: travis: checkout test repo to correct branch

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -16,6 +16,10 @@ clone_tests_repo()
 	fi
 
 	go get -d -u "$tests_repo" || true
+
+	if [ -n "${TRAVIS_BRANCH:-}" ]; then
+		( cd "${tests_repo_dir}" && git checkout "${TRAVIS_BRANCH}" )
+	fi
 }
 
 run_static_checks()

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ language: go
 go_import_path: github.com/kata-containers/shim
 
 go:
-  - "1.10.x"
+  - "1.11.x"
 
 env:
   - target_branch=$TRAVIS_BRANCH

--- a/terminal_darwin.go
+++ b/terminal_darwin.go
@@ -25,8 +25,7 @@ func setupTerminal(fd int) (*unix.Termios, error) {
 		return nil, err
 	}
 
-	var savedTermios unix.Termios
-	savedTermios = *termios
+	savedTermios := *termios
 
 	// Set the terminal in raw mode
 	termios.Iflag &^= termiosIFlagRawTermInvMask


### PR DESCRIPTION
If we are testing an stable branch, we need to checkout
to the correct branch on the tests repository.

Fixes: #158.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>