### PR TITLE
travis: update go version used in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ language: go
 go_import_path: github.com/kata-containers/shim
 
 go:
-  - "1.10.x"
+  - "1.11.x"
 
 env:
   - target_branch=$TRAVIS_BRANCH

--- a/agent_test.go
+++ b/agent_test.go
@@ -90,7 +90,7 @@ func newTestSpec() *pb.Spec {
 		Version: "testGrpcVersion",
 		Process: &pb.Process{
 			Terminal:     true,
-			ConsoleSize:  &pb.Box{10, 10},
+			ConsoleSize:  &pb.Box{Height: 10, Width: 10},
 			User:         pb.User{UID: 0, GID: 0, Username: "root:root"},
 			Capabilities: &pb.LinuxCapabilities{},
 			Rlimits:      []pb.POSIXRlimit{},

--- a/terminal_darwin.go
+++ b/terminal_darwin.go
@@ -25,8 +25,7 @@ func setupTerminal(fd int) (*unix.Termios, error) {
 		return nil, err
 	}
 
-	var savedTermios unix.Termios
-	savedTermios = *termios
+	savedTermios := *termios
 
 	// Set the terminal in raw mode
 	termios.Iflag &^= termiosIFlagRawTermInvMask

--- a/terminal_linux.go
+++ b/terminal_linux.go
@@ -27,8 +27,7 @@ func setupTerminal(fd int) (*unix.Termios, error) {
 		return nil, err
 	}
 
-	var savedTermios unix.Termios
-	savedTermios = *termios
+	savedTermios := *termios
 
 	// Set the terminal in raw mode
 	termios.Iflag &^= termiosIFlagRawTermInvMask


### PR DESCRIPTION
Update from go 1.10 to 1.11

Fixes: #163.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>
(cherry picked from commit 741421a89fb505128050e4ba1244113cb30fabd9)
Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>