### PR TITLE
CI: allow osx builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
     - os: linux
       sudo: required
       dist: xenial
+  allow_failures:
+    - os: osx
 
 language: go
 go_import_path: github.com/kata-containers/shim


### PR DESCRIPTION
osx builds on travis are failing to find linux tools like getopt and
curl. Temporarily allowing them to fail while this is being worked out.

Fixes: #183

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>