### PR TITLE
trace: Add missing log message

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -83,5 +83,12 @@ func trace(parent context.Context, name string) (opentracing.Span, context.Conte
 
 	span.SetTag("source", "shim")
 
+	// This is slightly confusing: when tracing is disabled, trace spans
+	// are still created - but the tracer used is a NOP. Therefore, only
+	// display the message when tracing is really enabled.
+	if tracing {
+		shimLog.Debugf("created span %v", span)
+	}
+
 	return span, ctx
 }


### PR DESCRIPTION
Add a log message for every trace span created, required by the tracing tests to validate tracing is working.

Fixes: #189.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>