### PR TITLE
ci: Allow travis to use go install script

### DIFF
--- a/.ci/install_go.sh
+++ b/.ci/install_go.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+clone_tests_repo
+
+pushd "${tests_repo_dir}"
+.ci/install_go.sh -p -f
+popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,18 +21,16 @@ matrix:
 language: go
 go_import_path: github.com/kata-containers/shim
 
-go:
-  - "1.11.x"
-
 env:
   - target_branch=$TRAVIS_BRANCH
 
 before_script:
+  - ".ci/install_go.sh"
   - ".ci/static-checks.sh"
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq              ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y -qq automake ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y -qq automake moreutils ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bash; fi
 
 install:


### PR DESCRIPTION
This allows travis to use the go install script instead of having a
hard coded golang version at travis.yml

Fixes #199

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>