### PR TITLE
Makefile: overwrite PREFIX from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@
 #
 
 DESTDIR :=
+ifeq ($(PREFIX),)
 PREFIX := /usr
+endif
 LIBEXECDIR := $(PREFIX)/libexec
 PROJECT := kata-containers
 # Override will ignore PREFIX, LIBEXECDIR and PROJECT


### PR DESCRIPTION
Allow scripts overwrite PREFIX from environment in order to install shim in a
specific path

fixes #224

Signed-off-by: Julio Montes <julio.montes@intel.com>