### PR TITLE
ci: Do not run unit tests with podman

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -7,5 +7,8 @@ set -e
 
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
+export CI_JOB="${CI_JOB:-default}"
 
-run_go_test
+if [ "${CI_JOB}" != "PODMAN" ]; then
+	run_go_test
+fi


### PR DESCRIPTION
For podman CI, we will not run the unit tests.

Fixes #230

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>