### PR TITLE
travis: specify golang version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,15 @@ matrix:
     - os: osx
 
 language: go
+go:
+  - 1.13.9
+
 go_import_path: github.com/kata-containers/shim
 
 env:
   - target_branch=$TRAVIS_BRANCH
 
 before_script:
-  - ".ci/install_go.sh"
   - ".ci/static-checks.sh"
 
 before_install:


### PR DESCRIPTION
Specify golang 1.13.9 in travis file and delete call to the
`.ci/install_go.sh` script as it is not working properly
in travis environment.

Fixes: #244.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>
(cherry picked from commit 21a545142673a76fd06b3b2cd28f78c9230b29ff)