### PR TITLE
Fix kata-shim residual

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,6 +58,8 @@ const (
 
 	// delay before trying to connect again
 	hybridVSockConnectDelay = time.Millisecond * 300
+
+	grpcTimeout = time.Second * 10
 )
 
 // version is the shim version. This variable is populated at build time.

--- a/shim.go
+++ b/shim.go
@@ -180,7 +180,8 @@ func (s *shim) wait() (int32, error) {
 	span, _ := trace(s.ctx, "wait")
 	defer span.Finish()
 
-	resp, err := s.agent.WaitProcess(s.ctx, &pb.WaitProcessRequest{
+	ctx, _ := context.WithTimeout(s.ctx, grpcTimeout)
+	resp, err := s.agent.WaitProcess(ctx, &pb.WaitProcessRequest{
 		ContainerId: s.containerID,
 		ExecId:      s.execID})
 	if err != nil {


### PR DESCRIPTION
we can' reproduce like this,
I did an exception test
1. killall -9 qemu-system-x86_64, kill katacontainers'vm, there is
   only one katacontainer, so I use killall, if there are more
   than one, please use kill -9 $PidOfShim.
2. Observe the kata-shim process. I expect the all the kata-shim
   process to exit, but it not.

Fixes: #272

the root cause the kata-shim not exit is that kata-shim hung in s.agent.WaitProcess,  I add a timeout for WaitProcess in this pr.

Signed-off-by: Shukui Yang <keloyangsk@gmail.com>